### PR TITLE
Chris/fix/get var

### DIFF
--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -78,7 +78,14 @@
         
         id<GAITracker> tracker = [[GAI sharedInstance] defaultTracker];
         NSString* parameterName = [command.arguments objectAtIndex:0];
-        NSString* result = [tracker get:parameterName];   
+
+        NSString* result;
+        @try {
+            result = [tracker get:parameterName];
+        }
+        @catch (NSException *exception) {
+            result = nil;
+        }
 
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:result];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];             

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-google-analytics",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Google Universal Analytics Plugin",
   "cordova": {
     "id": "cordova-plugin-google-analytics",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/danwilson/google-analytics-plugin.git"
+    "url": "https://github.com/MoveGB/google-analytics-plugin.git"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-google-analytics"
-    version="1.8.3">
+    version="1.8.4">
   <engines>
     <engine name="cordova" version=">=3.0.0" />
   </engines>


### PR DESCRIPTION
This PR provides a quick n dirty fix to the problem described below:

If we try to query a UTM parameter that has not been set, it crashes our app with the same exception as described here: https://stackoverflow.com/questions/38850192/google-analytics-sdk-ios10

One of the answers to that question expains that with iOS 10, Apple changed the API for `NSObject#valueForKey`. The Google Analytics iOS SDK evidently uses this method under the hood when attempting to retrieve UTM parameters from the analytics tracker instance. If the answer is correct, the behaviour would suggest that `valueForKey` is being called with a `nil` parameter. I'm not exactly clear why this is happening, as I can see in the debugger that we call `GAITracker#get` with a non-`nil` string, so perhaps the `GAITracker` instance is turning unrecognised keys into `nil`s?

Unfortunately, it's fair to assume that many such keys will be unset (different installations will carry a variety of UTM parameters, and some will lack them completely). To compound matters, the parameter names exposed by the iOS SDK differ to those described in Google's docs (https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters). This wouldn't be a problem for native iOS development, because the iOS SDK provides named constants (`kMyMagicConstant` etc.) to spare developers from having to use magic strings. However, the Cordova plugin API `getVar()` expects a raw string.